### PR TITLE
Support Hook Event Dispatcher versions `4.0@RC` and future `4.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   "require": {
     "php": ">=8.0.0",
     "drupal/core": "^9.0 || ^10.0",
-    "drupal/hook_event_dispatcher": "^3.2 || ^4.0@beta",
+    "drupal/hook_event_dispatcher": "^3.2 || ^4.0@beta || ^4.0@RC || ^4.0",
     "drupal/inline_entity_form": "^1.0@RC"
   },
   "require-dev": {


### PR DESCRIPTION
cf. https://wieni.slack.com/archives/C0100DYTAP8/p1699434470710319